### PR TITLE
Add data-content='item' attribute to the generated span tags.

### DIFF
--- a/jquery.lettering.js
+++ b/jquery.lettering.js
@@ -15,7 +15,7 @@
 		var a = t.text().split(splitter), inject = '';
 		if (a.length) {
 			$(a).each(function(i, item) {
-				inject += '<span class="'+klass+(i+1)+'" data-content="'+item+'">'+item+'</span>'+after;
+				inject += '<span class="'+klass+(i+1)+'" data-content="'+item.split('"').join('&quot;')+'">'+item+'</span>'+after;
 			});	
 			t.empty().append(inject);
 		}


### PR DESCRIPTION
Add <tt>data-content='item'</tt> attribute to the generated span tags. 

This hook allows for dynamic use of :before and :after pseudo elements to layer text by way of a attr() call.

``` css
span.char1:before {
  content: attr(data-content);
  ... 
}
```

No more hard coding textual content in css files!
