### PR TITLE
Add a character-specific class to letters

### DIFF
--- a/jquery.lettering.js
+++ b/jquery.lettering.js
@@ -21,7 +21,10 @@
 		},
 
 		char: function(i, char) {
-			quot = char.match(/[&"]/) ? "'" : '"';
+			if (char === '&') {
+				char = '&amp;';
+			}
+			quot = char === '"' ? "'" : '"';
 			return '<span class="char'+(i+1)+'" data-char='+quot+char+quot+'>'+char+'</span>';
 		}
 	};


### PR DESCRIPTION
It can be useful to kern every instance of certain letter combinations. With these extra classes, you can apply broad css rules. For example, to consistently tighten the space between the characters "A" and "W" in headlines, you could use the css rule `.char-a + .char-w { margin-left:-2px; }`
