### PR TITLE
Exclude example using bower install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "0.6.1",
   "main": "jquery.lettering.js",
   "ignore": [
+    "examples",
     "**/.*"
   ],
   "dependencies": {


### PR DESCRIPTION
When I install Lattering.js, hope to excludes examples dir :)

Thanks
