### PR TITLE
Copying item to the data attribute of the span

### DIFF
--- a/jquery.lettering.js
+++ b/jquery.lettering.js
@@ -15,7 +15,7 @@
 		var a = t.text().split(splitter), inject = '';
 		if (a.length) {
 			$(a).each(function(i, item) {
-				inject += '<span class="'+klass+(i+1)+'">'+item+'</span>'+after;
+				inject += '<span class="'+klass+(i+1)+'" data-character="'+item+'">'+item+'</span>'+after;
 			});	
 			t.empty().append(inject);
 		}


### PR DESCRIPTION
Added `item` to "data-character" a custom HTML 5 data attribute of the span. This can then be called by pseudo elements using `content: attr(data-character);`.

This works for my [use case](http://codepen.io/alienresident/pen/mhqrj) but I think it would be more useful to add `data-{method}="'+item+'"`. So you could have data-character, data-word, data-line attributes depending on what method(s) you used. I am not sure how to do this.... 

It may also be useful to call this additional code only if you want it.Perhaps by calling an additional argument? 

Thoughts?
